### PR TITLE
Fix searching with stop_words: use them for needle

### DIFF
--- a/lib/fuzzy_match.rb
+++ b/lib/fuzzy_match.rb
@@ -138,9 +138,9 @@ class FuzzyMatch
     
     needle = case needle
     when String
-      Record.new needle
+      Record.new needle, :stop_words => stop_words
     else
-      Record.new needle, :read => read
+      Record.new needle, :read => read, :stop_words => stop_words
     end
     
     if gather_last_result


### PR DESCRIPTION
Given:
   stop_words: ['bar']
   haystack: ['foo bar']
When:
  searching for needle ['foo bar']
Expected result:
  found 'foo bar' and best score is 1.0 (because strings are identical)

Actual result: 
 found 'foo bar' but best score is NOT 1.0

Reason:
  stop_words are not used on the needle

Probably should be fixed?
