### PR TITLE
Add a JRuby version using java-string-similarity

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -165,6 +165,23 @@ You can optionally use [`amatch`](http://flori.github.com/amatch/) by [Florian F
 
 Otherwise, pure ruby versions of the string similarity algorithms derived from the [answer to a StackOverflow question](http://stackoverflow.com/questions/653157/a-better-similarity-ranking-algorithm-for-variable-length-strings) and [the text gem](https://github.com/threedaymonk/text/blob/master/lib/text/levenshtein.rb) are used. Thanks [marzagao](http://stackoverflow.com/users/10997/marzagao) and [threedaymonk](https://github.com/threedaymonk)!
 
+## JRuby usage
+
+In addition to amatch you can also use JRuby with a Java library.
+In order to do that, you have to add jbundler to your Gemfile:
+
+    platform :jruby do
+      gem 'jbundler'
+    end
+
+and you need a Jarfile containing
+
+    jar 'info.debatty:java-string-similarity'
+
+The engine has to be set to jruby then:
+
+    FuzzyMatch.engine = :jruby
+
 ## Real-world usage
 
 <p><a href="http://brighterplanet.com"><img src="https://s3.amazonaws.com/static.brighterplanet.com/assets/logos/flush-left/inline/green/rasterized/brighter_planet-160-transparent.png" alt="Brighter Planet logo"/></a></p>

--- a/lib/fuzzy_match.rb
+++ b/lib/fuzzy_match.rb
@@ -19,6 +19,8 @@ class FuzzyMatch
     
     def score_class
       case engine
+      when :jruby
+        Score::JRuby
       when :pure_ruby
         Score::PureRuby
       when :amatch

--- a/lib/fuzzy_match/score.rb
+++ b/lib/fuzzy_match/score.rb
@@ -1,5 +1,6 @@
 require 'fuzzy_match/score/pure_ruby'
 require 'fuzzy_match/score/amatch'
+require 'fuzzy_match/score/jruby'
 
 class FuzzyMatch
   class Score

--- a/lib/fuzzy_match/score/jruby.rb
+++ b/lib/fuzzy_match/score/jruby.rb
@@ -1,0 +1,27 @@
+class FuzzyMatch
+  class Score
+    # be sure to run this with JRuby
+    class JRuby < Score
+
+      def dices_coefficient_similar
+        @dices_coefficient_similar ||= if str1 == str2
+          1.0
+        elsif str1.length == 1 and str2.length == 1
+          0.0
+        else
+          java_import "info.debatty.java.stringsimilarity.SorensenDice"
+          Java::InfoDebattyJavaStringsimilarity::SorensenDice.new(2).similarity(str1, str2)
+        end
+      end
+
+      def levenshtein_similar
+        @levenshtein_similar ||= levenshtein
+      end
+
+      def levenshtein
+        java_import "info.debatty.java.stringsimilarity.Levenshtein"
+        1 - Java::InfoDebattyJavaStringsimilarity::Levenshtein.new.distance(str1, str2)
+      end
+    end
+  end
+end

--- a/spec/amatch_spec.rb
+++ b/spec/amatch_spec.rb
@@ -1,7 +1,7 @@
 unless RUBY_PLATFORM == 'java'
   require 'spec_helper'
   require 'amatch'
-  
+
   describe FuzzyMatch do
     describe %{when using the :amatch string similarity engine} do
       before do


### PR DESCRIPTION
As amatch tends to produce segfaults lately, we added a different option to use jruby and the java matching library https://github.com/tdebatty/java-string-similarity

All thanks and praises to @nightscape
