### PR TITLE
Improve algorithm for Dice Coefficient

### DIFF
--- a/lib/fuzzy_match/similarity.rb
+++ b/lib/fuzzy_match/similarity.rb
@@ -23,7 +23,6 @@ class FuzzyMatch
 
     def satisfy?(needle, threshold)
       best_score.dices_coefficient_similar > (threshold || 0) or
-        ((record2.clean.length < 3 or needle.clean.length < 3) and best_score.levenshtein_similar > 0) or
         (threshold.nil? && (needle.words & record2.words).any?)
     end
 


### PR DESCRIPTION
Pad words at start and end to compensate for underweighting of characters
at word edges. In FuzzyMatch::Similarity, remove fallback to Levenshtein
for words < 3 characters long.

(Fix for issue #22.)